### PR TITLE
Correct generateAccessToken invocation

### DIFF
--- a/lib/grant-types/implicit-grant-type.js
+++ b/lib/grant-types/implicit-grant-type.js
@@ -63,7 +63,7 @@ ImplicitGrantType.prototype.handle = function(request, client) {
 ImplicitGrantType.prototype.saveToken = function(user, client, scope) {
   var fns = [
     this.validateScope(user, client, scope),
-    this.generateAccessToken(),
+    this.generateAccessToken(client, user, scope),
     this.getAccessTokenExpiresAt()
   ];
 


### PR DESCRIPTION
Correct `generateAccessToken` invocation to include the correct parameters