### PR TITLE
feat/support public clients with no client secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@
 Complete, compliant and well tested module for implementing an OAuth2 server in [Node.js](https://nodejs.org).
 
 
+## Allthings Custom implementation
+Due to the lack of maintenance of the project this was forked @allthings.
+
+### Changes since fork (by Allthings)
+
+1. Bug-fix for query parameters in the redirect_uri during authorization.
+1. `isClientAuthenticationRequired` can now be overwritten in for the server options allowing us to not require a `client_secret` for public clients.
+
+
 ## Installation
 
 ```bash

--- a/docs/api/oauth2-server.rst
+++ b/docs/api/oauth2-server.rst
@@ -237,6 +237,8 @@ Retrieves a new token for an authorized token request.
 +----------------------------------------------+-----------------+-------------------------------------------------------------------------------------------+
 | [options.requireClientAuthentication={}]     | Object          | Require a client secret (see remarks section). Defaults to ``true`` for all grant types.  |
 +----------------------------------------------+-----------------+-------------------------------------------------------------------------------------------+
+| [options.isClientAuthenticationRequired]     | Function        | Overwrite the behavior which client requires client authentication for a grant.           |
++----------------------------------------------+-----------------+-------------------------------------------------------------------------------------------+
 | [options.alwaysIssueNewRefreshToken=true]    | Boolean         | Always revoke the used refresh token and issue a new one for the ``refresh_token`` grant. |
 +----------------------------------------------+-----------------+-------------------------------------------------------------------------------------------+
 | [options.extendedGrantTypes={}]              | Object          | Additional supported grant types.                                                         |

--- a/lib/handlers/token-handler.js
+++ b/lib/handlers/token-handler.js
@@ -61,6 +61,7 @@ function TokenHandler(options) {
   this.refreshTokenLifetime = options.refreshTokenLifetime;
   this.allowExtendedTokenAttributes = options.allowExtendedTokenAttributes;
   this.requireClientAuthentication = options.requireClientAuthentication || {};
+  this.isClientAuthenticationRequired = options.isClientAuthenticationRequired || this.isClientAuthenticationRequired;
   this.alwaysIssueNewRefreshToken = options.alwaysIssueNewRefreshToken !== false;
 }
 
@@ -116,15 +117,12 @@ TokenHandler.prototype.handle = function(request, response) {
  */
 
 TokenHandler.prototype.getClient = function(request, response) {
+  var me = this;
   var credentials = this.getClientCredentials(request);
   var grantType = request.body.grant_type;
 
   if (!credentials.clientId) {
     throw new InvalidRequestError('Missing parameter: `client_id`');
-  }
-
-  if (this.isClientAuthenticationRequired(grantType) && !credentials.clientSecret) {
-    throw new InvalidRequestError('Missing parameter: `client_secret`');
   }
 
   if (!is.vschar(credentials.clientId)) {
@@ -139,6 +137,10 @@ TokenHandler.prototype.getClient = function(request, response) {
     .then(function(client) {
       if (!client) {
         throw new InvalidClientError('Invalid client: client is invalid');
+      }
+
+      if (me.isClientAuthenticationRequired(grantType, client) && !credentials.clientSecret) {
+        throw new InvalidRequestError('Missing parameter: `client_secret`');
       }
 
       if (!client.grants) {
@@ -177,20 +179,17 @@ TokenHandler.prototype.getClient = function(request, response) {
 
 TokenHandler.prototype.getClientCredentials = function(request) {
   var credentials = auth(request);
-  var grantType = request.body.grant_type;
 
   if (credentials) {
     return { clientId: credentials.name, clientSecret: credentials.pass };
   }
 
-  if (request.body.client_id && request.body.client_secret) {
-    return { clientId: request.body.client_id, clientSecret: request.body.client_secret };
-  }
-
-  if (!this.isClientAuthenticationRequired(grantType)) {
-    if(request.body.client_id) {
-      return { clientId: request.body.client_id };
+  if (request.body.client_id) {
+    var result = { clientId: request.body.client_id };
+    if (request.body.client_secret) {
+      result.clientSecret = request.body.client_secret;
     }
+    return result
   }
 
   throw new InvalidClientError('Invalid client: cannot retrieve client credentials');

--- a/test/integration/handlers/token-handler_test.js
+++ b/test/integration/handlers/token-handler_test.js
@@ -527,6 +527,20 @@ describe('TokenHandler integration', function() {
         .catch(should.fail);
     });
 
+    it('should throw an error if `client_secret` is missing', function() {
+      var model = {
+        getClient: function() {return {id: 12345, public: true, grants: []}},
+        saveToken: function() {}
+      };
+      var handler = new TokenHandler({ accessTokenLifetime: 120, model: model, refreshTokenLifetime: 120 });
+      var request = new Request({ body: { client_id: 'foo' }, headers: {}, method: {}, query: {} });
+
+      return handler.getClient(request).then(should.fail).catch(function (e) {
+        e.should.be.an.instanceOf(InvalidRequestError);
+        e.message.should.equal('Missing parameter: `client_secret`');
+      });
+    });
+
     describe('with `password` grant type and `requireClientAuthentication` is false', function() {
 
       it('should return a client ', function() {
@@ -628,24 +642,6 @@ describe('TokenHandler integration', function() {
       };
       var handler = new TokenHandler({ accessTokenLifetime: 120, model: model, refreshTokenLifetime: 120 });
       var request = new Request({ body: { client_secret: 'foo' }, headers: {}, method: {}, query: {} });
-
-      try {
-        handler.getClientCredentials(request);
-
-        should.fail();
-      } catch (e) {
-        e.should.be.an.instanceOf(InvalidClientError);
-        e.message.should.equal('Invalid client: cannot retrieve client credentials');
-      }
-    });
-
-    it('should throw an error if `client_secret` is missing', function() {
-      var model = {
-        getClient: function() {},
-        saveToken: function() {}
-      };
-      var handler = new TokenHandler({ accessTokenLifetime: 120, model: model, refreshTokenLifetime: 120 });
-      var request = new Request({ body: { client_id: 'foo' }, headers: {}, method: {}, query: {} });
 
       try {
         handler.getClientCredentials(request);


### PR DESCRIPTION
With app not being able to keep the client secret a secret we want to support 'public' clients, that don't require a secret to exchange an auth code to an access token.